### PR TITLE
Handle transaction conflicts on server start-up

### DIFF
--- a/repository/GsApplicationTools-Server.package/GemServer.class/instance/transactionMode..st
+++ b/repository/GsApplicationTools-Server.package/GemServer.class/instance/transactionMode..st
@@ -2,6 +2,11 @@ accessing
 transactionMode: aSymbol
   "#autoBegin or #manualBegin"
 
-  self doTransaction: [ transactionMode := aSymbol ].
+  "Use doBasicTransaction and repeat till success instead of throwing an exception,
+  because it is likely to run into transaction conflicts here if server starts up with multiple processes."
+
+  [	self doBasicTransaction: [ transactionMode := aSymbol ]
+  ]	whileFalse:[(Delay forMilliseconds: (Random new integerBetween: 0 and: 150)) wait].
+  
   System transactionMode == aSymbol
     ifFalse: [ System transactionMode: aSymbol ]


### PR DESCRIPTION
Hello Dale,
I rarely ended with the desired number of running topaz processes when starting a zinc server on multiple ports. Investigation of the logs showed transaction conflicts when setting the shared state of instVar transactionMode. This fix works for me.
Br,
Ralph
